### PR TITLE
Fix "window is not defined"

### DIFF
--- a/lib/components/Recaptcha.js
+++ b/lib/components/Recaptcha.js
@@ -2,7 +2,7 @@ import React, { PureComponent } from 'react';
 
 import PropTypes from 'prop-types';
 
-const isReady = () => Boolean(window && window.grecaptcha && window.grecaptcha.render);
+const isReady = () => Boolean(typeof window === 'object' && window.grecaptcha && window.grecaptcha.render);
 
 export default class Recaptcha extends PureComponent {
 


### PR DESCRIPTION
Trying to use `react-recaptcha-that-works` in gatsby results in the following error when building the site:

> ReferenceError: window is not defined

This PR fixes the issue.