### PR TITLE
closes #2

### DIFF
--- a/lib/components/Recaptcha.js
+++ b/lib/components/Recaptcha.js
@@ -92,23 +92,33 @@ export default class Recaptcha extends PureComponent {
             this.onCloseObserver.disconnect();
         }
 
-        const iframes = document.getElementsByTagName('iframe');
-        const recaptchaFrame = Array.prototype.find
-            .call(iframes, e => e.src.includes('google.com/recaptcha/api2/bframe'));
-        const recaptchaElement = recaptchaFrame.parentNode.parentNode;
+        const onIframeEnterObserver = new MutationObserver(mutations => {
+            mutations.forEach(mutation => {
+                []
+                    .filter
+                    .call(mutation.addedNodes, node => node.nodeName.toUpperCase() === 'IFRAME')
+                    .forEach(iframe => {
+                        if (iframe.src.includes('google.com/recaptcha/api2/bframe')) {
+                            const recaptchaElement = iframe.parentNode.parentNode;
+                            let lastOpacity = recaptchaElement.style.opacity;
 
-        let lastOpacity = recaptchaElement.style.opacity;
-        this.onCloseObserver = new MutationObserver(mutations => {
-            if (lastOpacity !== recaptchaElement.style.opacity
-                && recaptchaElement.style.opacity == 0) { // eslint-disable-line eqeqeq
-                this.props.onClose();
-            }
-            lastOpacity = recaptchaElement.style.opacity;
+                            this.onCloseObserver = new MutationObserver(() => {
+                                if (lastOpacity !== recaptchaElement.style.opacity
+                                    && recaptchaElement.style.opacity == 0) { // eslint-disable-line eqeqeq
+                                    this.props.onClose();
+                                }
+                                lastOpacity = recaptchaElement.style.opacity;
+                            });
+
+                            this.onCloseObserver.observe(recaptchaElement, {
+                                attributes: true,
+                                attributeFilter: ['style'],
+                            });
+                        }
+                    });
+            });
         });
-        this.onCloseObserver.observe(recaptchaElement, {
-            attributes: true,
-            attributeFilter: ['style'],
-        });
+        onIframeEnterObserver.observe(document.body, { childList: true, subtree: true });
     }
 
     _renderRecaptcha() {


### PR DESCRIPTION
Fixes `onClose` callback error.

When the method `_registerOnCloseListener` was called, right before any other method in execute, the iframe for recaptcha challenge was not built yet.

This PR modifies this behavior, making the app observe for any new Iframe created in the body. When the challenge iframe is created, the `onClose` callback is bound, and then works properly when this window is closed.