### PR TITLE
Fix "Recaptcha has already been rendered"

### DIFF
--- a/lib/Recaptcha.tsx
+++ b/lib/Recaptcha.tsx
@@ -76,20 +76,13 @@ const Recaptcha = forwardRef(({
   };
 
   useEffect(() => {
-    if (ready) {
+    if (ready && !isRendered()) {
       renderRecaptcha();
       return;
     }
 
     readyIntervalRef.current = setInterval(updateReadyState, 1000);
     return () => clearInterval(readyIntervalRef.current);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [ready]);
-
-  useEffect(() => {
-    if (ready && !isRendered()) {
-      renderRecaptcha();
-    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ready]);
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-recaptcha-that-works",
   "description": "⚛ A reCAPTCHA bridge for React that works.",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "main": "lib/index.ts",
   "repository": {
     "type": "git",


### PR DESCRIPTION
- **fix: remove react strict mode double render error React 19's Strict Mode causes components to mount twice in development, which triggers reCAPTCHA's "already rendered" error. The Google reCAPTCHA library maintains internal state and throws when attempting to render the same widget multiple times in the same DOM element.**
<img width="991" height="316" alt="Screenshot 2025-11-24 at 11 53 20" src="https://github.com/user-attachments/assets/f4acb3cc-05ab-42ae-95e1-ded938a26798" />


- **feat: bump version**

